### PR TITLE
[chore] Fix copyright notices.

### DIFF
--- a/examples/rest/CURL.sh
+++ b/examples/rest/CURL.sh
@@ -1,12 +1,11 @@
 #!/bin/sh
-# 
-# Copyright 2018 Google LLC. All Rights Reserved.
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,4 +19,3 @@ curl "https://language.googleapis.com/v1/documents:analyzeEntities" \
  -H "Content-Type: application/json" \
  -d '{"document":{"content":"The rain in Spain stays mainly in the plain.", "type":"PLAIN_TEXT"}}' \
  -i
-

--- a/examples/rpc/go/main.go
+++ b/examples/rpc/go/main.go
@@ -1,10 +1,10 @@
-// Copyright 2018 Google LLC. All Rights Reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//    https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -78,4 +78,3 @@ func main() {
 	log.Printf("REQUEST: %+v", request)
 	log.Printf("RESPONSE: %+v", response)
 }
-

--- a/examples/rpc/rust/SETUP.sh
+++ b/examples/rpc/rust/SETUP.sh
@@ -1,12 +1,11 @@
 #!/bin/sh
-#
-# Copyright 2018 Google LLC. All Rights Reserved.
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,5 +31,4 @@ protoc \
 	google/api/http.proto \
 	google/protobuf/descriptor.proto \
  	-Igoogleapis \
-	--rust_out=src 
-
+	--rust_out=src

--- a/examples/rpc/rust/src/main.rs
+++ b/examples/rpc/rust/src/main.rs
@@ -1,10 +1,10 @@
-// Copyright 2018 Google LLC. All Rights Reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//    https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,11 +34,11 @@ fn main() {
     let mut document = language_service::Document::new();
     document.set_content(String::from("The rain in Spain stays mainly in the plain."));
     document.field_type = language_service::Document_Type::PLAIN_TEXT;
-	
+
     let mut analyze_entities_request = language_service::AnalyzeEntitiesRequest::new();
     analyze_entities_request.set_document(document);
     analyze_entities_request.encoding_type = language_service::EncodingType::UTF8;
-    
+
 	let serialized_bytes = analyze_entities_request.write_to_bytes().unwrap();
 
     let client = reqwest::Client::new();

--- a/examples/rpc/swift/Package.swift
+++ b/examples/rpc/swift/Package.swift
@@ -1,11 +1,12 @@
 // swift-tools-version:4.0
 
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//    https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/rpc/swift/SETUP.sh
+++ b/examples/rpc/swift/SETUP.sh
@@ -1,12 +1,11 @@
 #!/bin/sh
-#
-# Copyright 2018 Google LLC. All Rights Reserved.
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +31,7 @@ protoc \
 	google/api/http.proto \
 	google/protobuf/descriptor.proto \
  	-Igoogleapis \
-	--swift_out=googleapis 
+	--swift_out=googleapis
 
 # move Swift files to the Sources directory
 find googleapis -name "*.swift" -exec mv {} Sources \;

--- a/examples/rpc/swift/Sources/main.swift
+++ b/examples/rpc/swift/Sources/main.swift
@@ -1,10 +1,10 @@
-// Copyright 2018 Google LLC. All Rights Reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//    https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
All of the license headers in this repository incorrectly read: "All Rights Reserved." This is false (the entire purpose of using an OSS license is _not_ to reserve many rights). This PR fixes it and some other license formatting quirks (e.g. still using a plain `http` link).